### PR TITLE
Hide directory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ URL_PREFIX=
 # served using HTTP.
 TLS_CERT=
 TLS_KEY=
+# Hide Listing (Only available when URL_PREFIX is set)
+SHOW_LISTING=
 ```
 
 ### Without Docker


### PR DESCRIPTION
Hi,
I want to hide my directory file (didn't want to use the famous `index.html`).

So, when passing `SHOW_LISTING=false` it will use a different handler to handle the request.
I've added it only to the prefix handler since I thought most people would like to use it with a prefix but I can add it to both handler if needed.