### PR TITLE
Dockerfile: Don't run as `root`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ COPY . .
 RUN go test -cover ./...
 RUN CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o /serve /build/bin/serve
 
+RUN adduser --system --no-create-home --uid 1000 --shell /usr/sbin/nologin static
+
 ################################################################################
 ## DEPLOYMENT CONTAINER
 ################################################################################
@@ -23,6 +25,9 @@ FROM scratch
 
 EXPOSE 8080
 COPY --from=builder /serve /
+COPY --from=builder /etc/passwd /etc/passwd
+
+USER static
 ENTRYPOINT ["/serve"]
 CMD []
 


### PR DESCRIPTION
Following security best practices, the server shouldn't run as `root` inside the container.