### PR TITLE
Bugfix/privileged ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ################################################################################
 ## GO BUILDER
 ################################################################################
-FROM golang:1.13.6 as builder
+FROM golang:1.13.7 as builder
 
-ENV VERSION 1.7.1
+ENV VERSION 1.7.2
 ENV BUILD_DIR /build
 
 RUN mkdir -p ${BUILD_DIR}
@@ -37,5 +37,5 @@ LABEL life.apets.vendor="Halverneus" \
     life.apets.url="https://github.com/halverneus/static-file-server" \
     life.apets.name="Static File Server" \
     life.apets.description="A tiny static file server" \
-    life.apets.version="v1.7.1" \
+    life.apets.version="v1.7.2" \
     life.apets.schema-version="1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN go test -cover ./...
 RUN CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o /serve /build/bin/serve
 
 RUN adduser --system --no-create-home --uid 1000 --shell /usr/sbin/nologin static
+RUN setcap cap_net_bind_service=+ep /serve
 
 ################################################################################
 ## DEPLOYMENT CONTAINER
@@ -33,8 +34,8 @@ CMD []
 
 # Metadata
 LABEL life.apets.vendor="Halverneus" \
-      life.apets.url="https://github.com/halverneus/static-file-server" \
-      life.apets.name="Static File Server" \
-      life.apets.description="A tiny static file server" \
-      life.apets.version="v1.7.1" \
-      life.apets.schema-version="1.0"
+    life.apets.url="https://github.com/halverneus/static-file-server" \
+    life.apets.name="Static File Server" \
+    life.apets.description="A tiny static file server" \
+    life.apets.version="v1.7.1" \
+    life.apets.schema-version="1.0"

--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -1,6 +1,6 @@
-FROM golang:1.13.6 as builder
+FROM golang:1.13.7 as builder
 
-ENV VERSION 1.7.1
+ENV VERSION 1.7.2
 ENV BUILD_DIR /build
 
 RUN mkdir -p ${BUILD_DIR}
@@ -21,5 +21,5 @@ LABEL life.apets.vendor="Halverneus" \
       life.apets.url="https://github.com/halverneus/static-file-server" \
       life.apets.name="Static File Server" \
       life.apets.description="A tiny static file server" \
-      life.apets.version="v1.7.1" \
+      life.apets.version="v1.7.2" \
       life.apets.schema-version="1.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # static-file-server
 
 ## Introduction
+
 Tiny, simple static file server using environment variables for configuration.
 Install from any of the following locations:
 


### PR DESCRIPTION
Re-allow the use of privileged ports (<1024) within the Docker container (requires building with Docker BuildKit).