### PR TITLE
Remove setting NET_BIND_SERVICE capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN go test -cover ./...
 RUN CGO_ENABLED=0 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o /serve /build/bin/serve
 
 RUN adduser --system --no-create-home --uid 1000 --shell /usr/sbin/nologin static
-RUN setcap cap_net_bind_service=+ep /serve
 
 ################################################################################
 ## DEPLOYMENT CONTAINER


### PR DESCRIPTION
This is not necessary, especially for the default configuration.

Also this allows dropping all capabilities