### PR TITLE
Removed the -race flag

### DIFF
--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -8,7 +8,7 @@ RUN mkdir -p ${BUILD_DIR}
 WORKDIR ${BUILD_DIR}
 
 COPY . .
-RUN go test -race -cover ./...
+RUN go test -cover ./...
 RUN GOOS=linux GOARCH=amd64 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-amd64/serve /build/bin/serve
 RUN GOOS=linux GOARCH=386 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-i386/serve /build/bin/serve
 RUN GOOS=linux GOARCH=arm GOARM=6 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-arm6/serve /build/bin/serve


### PR DESCRIPTION
Removed the -race flag from unit testing due to disabling CGO for cross-architecture testing. Choice is either compile for other architectures OR -race for testing... can't have both.