### PR TITLE
Remove debugging symbols in release builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 
+# Ignore the binary output directory (result of running update.sh).
+/out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 COPY . .
 
 RUN go test -cover ./...
-RUN go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o /serve /build/bin/serve
+RUN go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o /serve /build/bin/serve
 
 RUN adduser --system --no-create-home --uid 1000 --shell /usr/sbin/nologin static
 

--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -9,13 +9,13 @@ WORKDIR ${BUILD_DIR}
 
 COPY . .
 RUN go test -cover ./...
-RUN GOOS=linux GOARCH=amd64 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-amd64/serve /build/bin/serve
-RUN GOOS=linux GOARCH=386 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-i386/serve /build/bin/serve
-RUN GOOS=linux GOARCH=arm GOARM=6 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-arm6/serve /build/bin/serve
-RUN GOOS=linux GOARCH=arm GOARM=7 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-arm7/serve /build/bin/serve
-RUN GOOS=linux GOARCH=arm64 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-arm64/serve /build/bin/serve
-RUN GOOS=darwin GOARCH=amd64 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/darwin-amd64/serve /build/bin/serve
-RUN GOOS=windows GOARCH=amd64 go build -a -tags netgo -installsuffix netgo -ldflags "-X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/win-amd64/serve.exe /build/bin/serve
+RUN GOOS=linux GOARCH=amd64 go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-amd64/serve /build/bin/serve
+RUN GOOS=linux GOARCH=386 go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-i386/serve /build/bin/serve
+RUN GOOS=linux GOARCH=arm GOARM=6 go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-arm6/serve /build/bin/serve
+RUN GOOS=linux GOARCH=arm GOARM=7 go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-arm7/serve /build/bin/serve
+RUN GOOS=linux GOARCH=arm64 go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/linux-arm64/serve /build/bin/serve
+RUN GOOS=darwin GOARCH=amd64 go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/darwin-amd64/serve /build/bin/serve
+RUN GOOS=windows GOARCH=amd64 go build -a -tags netgo -installsuffix netgo -ldflags "-s -w -X github.com/halverneus/static-file-server/cli/version.version=${VERSION}" -o pkg/win-amd64/serve.exe /build/bin/serve
 
 # Metadata
 LABEL life.apets.vendor="Halverneus" \

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ $# -eq 0 ] ; then
+if [ $# -eq 0 ]; then
 	echo "Usage: ./update.sh v#.#.#"
 	exit
 fi
@@ -15,18 +15,18 @@ ID=$(docker create sfs-builder)
 
 rm -rf out
 mkdir -p out
-docker cp $ID:/build/pkg/linux-amd64/serve ./out/static-file-server-$VERSION-linux-amd64
-docker cp $ID:/build/pkg/linux-i386/serve ./out/static-file-server-$VERSION-linux-386
-docker cp $ID:/build/pkg/linux-arm6/serve ./out/static-file-server-$VERSION-linux-arm6
-docker cp $ID:/build/pkg/linux-arm7/serve ./out/static-file-server-$VERSION-linux-arm7
-docker cp $ID:/build/pkg/linux-arm64/serve ./out/static-file-server-$VERSION-linux-arm64
-docker cp $ID:/build/pkg/darwin-amd64/serve ./out/static-file-server-$VERSION-darwin-amd64
-docker cp $ID:/build/pkg/win-amd64/serve.exe ./out/static-file-server-$VERSION-windows-amd64.exe
+docker cp "${ID}:/build/pkg/linux-amd64/serve" "./out/static-file-server-${VERSION}-linux-amd64"
+docker cp "${ID}:/build/pkg/linux-i386/serve" "./out/static-file-server-${VERSION}-linux-386"
+docker cp "${ID}:/build/pkg/linux-arm6/serve" "./out/static-file-server-${VERSION}-linux-arm6"
+docker cp "${ID}:/build/pkg/linux-arm7/serve" "./out/static-file-server-${VERSION}-linux-arm7"
+docker cp "${ID}:/build/pkg/linux-arm64/serve" "./out/static-file-server-${VERSION}-linux-arm64"
+docker cp "${ID}:/build/pkg/darwin-amd64/serve" "./out/static-file-server-${VERSION}-darwin-amd64"
+docker cp "${ID}:/build/pkg/win-amd64/serve.exe" "./out/static-file-server-${VERSION}-windows-amd64.exe"
 
-docker rm -f $ID
+docker rm -f "${ID}"
 docker rmi sfs-builder
 
-docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag halverneus/static-file-server:$VERSION .
+docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag "halverneus/static-file-server:${VERSION}" .
 docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag halverneus/static-file-server:latest .
 
 echo "Done"


### PR DESCRIPTION
Currently, build output sizes are as follows (7.31M average):

```
7.3M static-file-server-v0.0.0-darwin-amd64
7.4M static-file-server-v0.0.0-linux-386
7.4M static-file-server-v0.0.0-linux-amd64
7.3M static-file-server-v0.0.0-linux-arm6
7.0M static-file-server-v0.0.0-linux-arm64
7.3M static-file-server-v0.0.0-linux-arm7
7.5M static-file-server-v0.0.0-windows-amd64.exe
```

With the included changes that strip out the symbol table and debug
information (see https://pkg.go.dev/cmd/link), we can reduce the size
of the binaries by ~30% (5.13M average):

```
5.5M static-file-server-v0.0.0-darwin-amd64
5.0M static-file-server-v0.0.0-linux-386
5.2M static-file-server-v0.0.0-linux-amd64
5.0M static-file-server-v0.0.0-linux-arm6
4.9M static-file-server-v0.0.0-linux-arm64
5.0M static-file-server-v0.0.0-linux-arm7
5.3M static-file-server-v0.0.0-windows-amd64.exe
```
