### PR TITLE
Cross Origin Resource Policy header

### DIFF
--- a/handle/handle.go
+++ b/handle/handle.go
@@ -168,6 +168,7 @@ func AddCorsWildcardHeaders(serve http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "*")
+		w.Header().Set("Cross-Origin-Resource-Policy", "cross-origin")
 		serve(w, r)
 	}
 }


### PR DESCRIPTION
My browser was still blocking access, even with the CORS flag set unless I add this header.